### PR TITLE
安装时报错,查看源码,应该是depsName key错误

### DIFF
--- a/packages/@jd/selling-lint-cli/src/lib/consts.ts
+++ b/packages/@jd/selling-lint-cli/src/lib/consts.ts
@@ -20,9 +20,9 @@ export const packageMap = {
     '@jd/stylelint-config-selling': 'stylelint'
   },
   depsName: {
-    '@jd/eslint-config-selling': 'eslintDeps',
-    '@jd/commitlint-config-selling': 'commitlintDeps',
-    '@jd/stylelint-config-selling': 'stylelintDeps'
+    'eslint-config-selling': 'eslintDeps',
+    'commitlint-config-selling': 'commitlintDeps',
+    'stylelint-config-selling': 'stylelintDeps'
   }
 }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
在执行s-lint init 时出错，报出
`(node:44102) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'includes' of undefined
    at /Users/mazhongjie/.nvm/versions/node/v14.15.4/lib/node_modules/selling-lint-cli/build/commands/init.js:29:28`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下那几个包:**

- [ ] eslint
- [ ] stylelint
- [ ] commitlint
- [x] lint-cli
